### PR TITLE
fix(account): Fix issue when current balance is not set in account table

### DIFF
--- a/src/main/java/com/factotum/setzer/config/JpaConfiguration.java
+++ b/src/main/java/com/factotum/setzer/config/JpaConfiguration.java
@@ -23,6 +23,7 @@ public class JpaConfiguration {
                 new ClassPathResource("test_data/drop_tables.sql"),
                 new ClassPathResource("db/migration/V1_0__create_mm_account_schema.sql"),
                 new ClassPathResource("db/migration/V2_0__add_tenant_id_column.sql"),
+                new ClassPathResource("db/migration/V2_3__add_non_null_constraint.sql"),
                 new ClassPathResource("test_data/V1_1__test_accounts.sql"),
                 new ClassPathResource("test_data/V2_1__add_tenant_id_in_tables.sql")
         );

--- a/src/main/java/com/factotum/setzer/controller/AccountController.java
+++ b/src/main/java/com/factotum/setzer/controller/AccountController.java
@@ -4,13 +4,9 @@ import com.factotum.setzer.dto.AccountDto;
 import com.factotum.setzer.model.Account;
 import com.factotum.setzer.repository.AccountRepository;
 import com.factotum.setzer.service.AccountService;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
-import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,6 +18,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import javax.validation.Valid;
+import java.math.BigDecimal;
 
 @Slf4j
 @RestController
@@ -51,6 +48,7 @@ public class AccountController {
     @PostMapping("")
     Mono<AccountDto> create(@Valid @RequestBody AccountDto newAccount) {
         Account account = new ModelMapper().map(newAccount, Account.class);
+        account.setCurrentBalance(BigDecimal.ZERO);
         return this.accountRepository.save(account).map(a -> new ModelMapper().map(a, AccountDto.class));
     }
 

--- a/src/main/java/com/factotum/setzer/service/AccountServiceImpl.java
+++ b/src/main/java/com/factotum/setzer/service/AccountServiceImpl.java
@@ -3,12 +3,14 @@ package com.factotum.setzer.service;
 import com.factotum.setzer.dto.AccountDto;
 import com.factotum.setzer.model.Account;
 import com.factotum.setzer.repository.AccountRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
 import static org.modelmapper.Conditions.isNotNull;
 
+@Slf4j
 @Service
 public class AccountServiceImpl implements AccountService {
 
@@ -24,7 +26,8 @@ public class AccountServiceImpl implements AccountService {
                 .map(account -> {
                     ModelMapper mapper = new ModelMapper();
                     mapper.getConfiguration().setPropertyCondition(isNotNull());
-                    return new ModelMapper().map(updatedAccount, Account.class);
+                    mapper.map(updatedAccount, account);
+                    return account;
                 }).flatMap(this.accountRepository::save);
     }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -32,9 +32,5 @@ spring:
   rabbitmq:
     username: test
     password: test
-
----
-
-logging:
-  level:
-    io.r2dbc: DEBUG
+    host: localhost
+    port: 5672

--- a/src/main/resources/db/migration/V2_3__add_non_null_constraint.sql
+++ b/src/main/resources/db/migration/V2_3__add_non_null_constraint.sql
@@ -1,0 +1,5 @@
+ALTER TABLE account MODIFY current_balance decimal NOT NULL;
+
+UPDATE account
+SET current_balance = 0
+WHERE current_balance IS NULL;

--- a/src/main/resources/test_data/V2_2__set_h2_mysql.sql
+++ b/src/main/resources/test_data/V2_2__set_h2_mysql.sql
@@ -1,0 +1,1 @@
+SET MODE MYSQL;

--- a/src/test/resources/test_data/drop_tables.sql
+++ b/src/test/resources/test_data/drop_tables.sql
@@ -1,2 +1,4 @@
+SET MODE MYSQL;
+
 DROP TABLE IF EXISTS account;
 DROP TABLE IF EXISTS account_type;


### PR DESCRIPTION
When updating a new accounts current balance, a null pointer was thrown. But the current balance should never be null. A non null constraint was added to the db and the create and update logic were updated to conform to this new constraint.

For https://app.asana.com/0/580094986677777/1200869929238011/f